### PR TITLE
Fix FontImage jsdocs

### DIFF
--- a/engine/engineDraw.js
+++ b/engine/engineDraw.js
@@ -287,7 +287,7 @@ let engineFontImage;
 class FontImage
 {
     /** Create an image font
-     *  @param {Image}   [image] - The image the font is stored in, if undefined the default font is used
+     *  @param {HTMLImageElement}   [image] - The image the font is stored in, if undefined the default font is used
      *  @param {Vector2} [tileSize=vec2(8)] - The size of the font source tiles
      *  @param {Vector2} [paddingSize=vec2(0,1)] - How much extra space to add between characters
      *  @param {Number}  [startTileIndex=0] - Tile index in image where font starts


### PR DESCRIPTION
I noticed that the type for the param `image` in the class `FontImage` was of type `new (width?: number, height?: number) => HTMLImageElement`. This doesn't make sense. I then realized this was because in the jsdocs for this class, the type was set as `Image`. In reality, the line `new Image(...)` returns an instance of `HTMLImageElement` so that's what the jsdocs should say.

Sorry, this is my first contribution to this project, and there's no contribution guidelines. Hope this PR makes sense.

Typescript code to reproduce the problem:

```ts
  const image = new Image(256, 24)
  image.src = 'font.png'
  font = new FontImage(image)
                       ^^^^^
```

Error from TS:

```
Argument of type 'HTMLImageElement' is not assignable to parameter of type 'new (width?: number, height?: number) => HTMLImageElement'.
  Type 'HTMLImageElement' provides no match for the signature 'new (width?: number, height?: number): HTMLImageElement'.
```