### PR TITLE
Performance improvements to stress test

### DIFF
--- a/examples/stress/index.html
+++ b/examples/stress/index.html
@@ -23,7 +23,7 @@ let sprites, timeMS, fpsDisplay, statsDisplay, spriteColor, spriteAdditiveColor;
 
 ///////////////////////////////////////////////////////////////////////////////
 
-class TestObject extends EngineObject 
+class TestObject extends EngineObject
 {
     constructor(pos)
     {
@@ -76,12 +76,12 @@ function gameUpdate()
         for (let i=100;i--;)
             sprites.push({
                 pos:mousePos.add(randInCircle(2)),
-                angle:rand(), 
+                angle:rand(),
                 velocity:randInCircle(.2),
-                color:spriteColor = spriteColor.mutate(), 
-                additiveColor:spriteAdditiveColor.mutate()
+                color:(spriteColor = spriteColor.mutate()).rgbaInt(),
+                additiveColor:spriteAdditiveColor.mutate().rgbaInt()
             });
-    
+
     // mouse wheel = zoom
     cameraScale = clamp(cameraScale*(1-mouseWheel/10), 1, 1e3);
 }
@@ -101,10 +101,10 @@ function gameRender()
 
     const spriteCount = sprites.length
     const objectCount = engineObjects.length;
-    statsDisplay.innerText = 
+    statsDisplay.innerText =
         spriteCount + objectCount ?
-            spriteCount + ' Sprites\n' 
-            + objectCount + ' Objects\n' 
+            spriteCount + ' Sprites\n'
+            + objectCount + ' Objects\n'
             + fpsDisplay.toFixed(1) + ' FPS'
         : 'LittleJS Stress Test\nLeft Click = Add Particles\nRight Click = Add Objects';
 
@@ -116,9 +116,10 @@ function gameRender()
 
         // apply gravity
         sprite.velocity.y += gravity;
-        
+
         // apply velocity
-        sprite.pos = sprite.pos.add(sprite.velocity);
+        sprite.pos.x += sprite.velocity.x;
+        sprite.pos.y += sprite.velocity.y;
 
         // bounce
         if (sprite.pos.y < 0)
@@ -132,8 +133,8 @@ function gameRender()
         sprite.angle += .01*sign(sprite.velocity.x);
 
         // draw the sprite
-        glDraw(sprite.pos.x, sprite.pos.y, 1, 1, sprite.angle, 0, 0, 1, 1, 
-            sprite.color.rgbaInt(), sprite.additiveColor.rgbaInt());
+        glDraw(sprite.pos.x, sprite.pos.y, 1, 1, sprite.angle, 0, 0, 1, 1,
+            sprite.color, sprite.additiveColor);
     }
 }
 


### PR DESCRIPTION
After the [instanced rendering PR](https://github.com/KilledByAPixel/LittleJS/pull/82), the new bottleneck is in the stress test itself.  The main culprit is all of the memory allocations from `Vector2.add()`, which allocates a new `Vector2`.

After changing the allocation to mutation, I now get 300k sprites at 80+ FPS.

![image](https://github.com/KilledByAPixel/LittleJS/assets/749094/cfbb1aec-629c-48fa-8c23-99cb666f7844)

Also, a pretty minor change to precomputing `rgbaInt()`, as the value doesn't change.

Before: https://killedbyapixel.github.io/LittleJS/examples/stress/

After: https://codyebberson.github.io/LittleJS/examples/stress/