### PR TITLE
Reset the main package file to the non-minified one

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "littlejsengine",
   "version": "1.11.1",
   "description": "LittleJS - Tiny and Fast HTML5 Game Engine",
-  "main": "dist/littlejs.esm.min.js",
+  "main": "dist/littlejs.esm.js",
   "types": "dist/littlejs.d.ts",
   "exports": {
     "types": "./dist/littlejs.d.ts",


### PR DESCRIPTION
During a discussion in the help channel on discord, we changed the `main` entry of the `package.json` to the release version of the engine. During some more research, I stumbled on #131 (and its PR #132), which already had been merged.
After some testing with the latest version, it seems that Vite will automatically choose the `production` export that is specified in the `exports` field of the `package.json` file.

I've included some more explanation and a screenshot in discord (https://discord.com/channels/939926111469568050/1305608485643354183/1322550578785685565)

