### PR TITLE
Allow user to set the debug variable (so is no longer a constant and has a new setter)

### DIFF
--- a/src/engineDebug.js
+++ b/src/engineDebug.js
@@ -17,7 +17,7 @@
  *  @type {boolean}
  *  @default
  *  @memberof Debug */
-const debug = true;
+let debug = true;
 
 /** Size to render debug points by default
  *  @type {number}
@@ -65,6 +65,13 @@ function ASSERT(assert, ...output)
  *  @param {...Object} output - message output
  *  @memberof Debug */
 function LOG(...output) { console.log(...output); }
+
+/** Set the value of the debug global variable
+*  @param {boolean} [newValue]
+*  @memberof Debug */
+function setDebug(newValue) {
+    debug = newValue;
+}
 
 /** Draw a debug rectangle in world space
  *  @param {Vector2} pos


### PR DESCRIPTION
Changed debug variable from const to let to allow reassignment and added setDebug function to modify its value.